### PR TITLE
Deprecate `BigEndian` & `LittleEndian`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,72 +20,11 @@
 ![badge-support-js-ir]
 ![badge-support-linux-arm]
 
-Big & Little Endian utils for Kotlin Multiplatform
-
-Small library which adds 2 kotlin `value class`es, `BigEndian` and `LittleEndian`
-
-### Usage
-
-```kotlin
-fun main() {
-    // Extension functions for converting Short, Int, or
-    // Long to LittleEndian or BigEndian
-    // e.g. Long.toLittleEndian()
-    val le = 5L.toLittleEndian()
-    val be = 5L.toBigEndian()
-    
-    println(le)
-    // LE[5,0,0,0,0,0,0,0]
-    println(be)
-    // BE[0,0,0,0,0,0,0,5]
-
-    println(le[0])
-    // 5
-    println(be[7])
-    // 5
-    
-    // Helper functions to convert bytes to Short, Int, or Long
-    val leLong = LittleEndian.bytesToLong(0, 0, 0, 5, 0, 0, 0, 10)
-    println(leLong)
-    // 720575940463165440
-    val beLong = BigEndian.bytesToLong(0, 0, 0, 5, 0, 0, 0, 10)
-    println(beLong)
-    // 21474836490
-
-    val bytes = ByteArray(le.size + be.size)
-    le.copyInto(bytes)
-    be.copyInto(bytes, le.size)
-    
-    // Safely convert BigEndian or LittleEndian to the desired
-    // primitives w/o worrying about the size of the underlying
-    // ByteArray
-    be.toByte()
-    be.toShort()
-    be.toInt()
-    be.toLong()
-    
-    // APIs for both classes are the same, with only 1 difference
-    be.toLittleEndian() // Convert a BigEndian to a LittleEndian
-    le.toBigEndian()    // Convert a LittleEndian to a BigEndian
-}
-```
-
-### Get Started
-
-The best way to keep `KotlinCrypto` dependencies up to date is by using the 
-[version-catalog][url-version-catalog]. Alternatively, see below.
+**NOTICE:** This library's functionality has been replaced by [KotlinCrypto/bitops][url-bitops]. Only critical 
+bug fixes will be made going forward, and eventually, archival of this repository.
 
 <!-- TAG_VERSION -->
-
-```kotlin
-// build.gradle.kts
-dependencies {
-    implementation("org.kotlincrypto.endians:endians:0.3.1")
-}
-```
-
-<!-- TAG_VERSION -->
-[badge-latest-release]: https://img.shields.io/badge/latest--release-0.3.1-blue.svg?style=flat
+[badge-latest-release]: https://img.shields.io/badge/latest--release-0.3.2-blue.svg?style=flat
 [badge-license]: https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat
 
 <!-- TAG_DEPENDENCIES -->
@@ -108,6 +47,7 @@ dependencies {
 [badge-support-js-ir]: https://img.shields.io/badge/support-[js--IR]-AAC4E0.svg?style=flat
 [badge-support-linux-arm]: http://img.shields.io/badge/support-[LinuxArm]-2D3F6C.svg?style=flat
 
+[url-bitops]: https://github.com/KotlinCrypto/bitops
 [url-latest-release]: https://github.com/KotlinCrypto/endians/releases/latest
 [url-license]: https://www.apache.org/licenses/LICENSE-2.0.txt
 [url-kotlin]: https://kotlinlang.org

--- a/library/endians/src/commonMain/kotlin/org/kotlincrypto/endians/BigEndian.kt
+++ b/library/endians/src/commonMain/kotlin/org/kotlincrypto/endians/BigEndian.kt
@@ -29,6 +29,7 @@ import kotlin.jvm.JvmStatic
  * @see [bytesToLong]
  * */
 @JvmInline
+@Deprecated("Functionality replaced by bitops/endian. See https://github.com/KotlinCrypto/bitops")
 public value class BigEndian private constructor(private val data: ByteArray) {
 
     /** [Short] 16 bits */

--- a/library/endians/src/commonMain/kotlin/org/kotlincrypto/endians/LittleEndian.kt
+++ b/library/endians/src/commonMain/kotlin/org/kotlincrypto/endians/LittleEndian.kt
@@ -29,6 +29,7 @@ import kotlin.jvm.JvmStatic
  * @see [bytesToLong]
  * */
 @JvmInline
+@Deprecated("Functionality replaced by bitops/endian. See https://github.com/KotlinCrypto/bitops")
 public value class LittleEndian private constructor(private val data: ByteArray) {
 
     /** [Short] 16 bits */


### PR DESCRIPTION
Closes #18 